### PR TITLE
Change PVC claim name to use the fullname

### DIFF
--- a/charts/hummingbot/templates/deployment.yaml
+++ b/charts/hummingbot/templates/deployment.yaml
@@ -65,4 +65,4 @@ spec:
           emptyDir: {}
         - name: hummingbot-conf
           persistentVolumeClaim:
-            claimName: hummingbot
+            claimName: {{ include "hummingbot.fullname" . }}


### PR DESCRIPTION
When I first installed this, I created the release as `hummingbot` which allowed this to work. However, any other release name doesn't work because the claim name is looking for `hummingbot`. This should keep it consistent.